### PR TITLE
Fix issue where test exceptions were not reported

### DIFF
--- a/src/main/java/com/github/ignaciotcrespo/junitwithparams/WithParamsRule.java
+++ b/src/main/java/com/github/ignaciotcrespo/junitwithparams/WithParamsRule.java
@@ -166,9 +166,10 @@ public class WithParamsRule implements MethodRule {
             }
         }
 
-        private void checkUsedParams() throws WithParamsException {
+        @VisibleForTesting
+        void checkUsedParams() throws WithParamsException {
             if (usedParams.size() > 0) {
-                throw new WithParamsException("Some parameters were never used! " + usedParams);
+                addError(new WithParamsException("Some parameters were never used! " + usedParams));
             }
         }
 
@@ -210,7 +211,8 @@ public class WithParamsRule implements MethodRule {
             System.out.println("Passed " + mParamsMap);
         }
 
-        private void addError(final Throwable exc) throws WithParamsException {
+        @VisibleForTesting
+        void addError(final Throwable exc) throws WithParamsException {
             String message = exc.getMessage();
             errorCollector.addError(new WithParamsException(formatted("Fail! " + mMethod.getName() +
                     "() -> " + mParamsMap

--- a/src/test/java/com/github/ignaciotcrespo/junitwithparams/ParameterizedStatementTest.java
+++ b/src/test/java/com/github/ignaciotcrespo/junitwithparams/ParameterizedStatementTest.java
@@ -1,0 +1,58 @@
+package com.github.ignaciotcrespo.junitwithparams;
+
+import com.github.ignaciotcrespo.junitwithparams.WithParamsRule.ParameterizedStatement;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class ParameterizedStatementTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private ParameterizedStatement statement;
+
+    private HashSet<String> usedParams;
+
+    @Before
+    public void setUp() throws Exception {
+        usedParams = new HashSet<String>();
+        statement = new ParameterizedStatement(
+                Collections.<String>emptySet(),
+                new HashMap<String, String>(),
+                null, null, null, usedParams);
+    }
+
+    @Test
+    public void checkParams_notEmpty() throws Exception {
+        // 1) Arrange
+        statement = spy(statement);
+
+        usedParams.add("stubParameter");
+
+        doNothing().when(statement).addError(any(Throwable.class));
+
+        // 2) Act
+        statement.checkUsedParams();
+
+        // 3) Assert
+        ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
+        verify(statement).addError(captor.capture());
+
+        assertThat(captor.getValue()).isInstanceOf(WithParamsException.class);
+        assertThat(captor.getValue().getMessage()).contains("stubParameter");
+    }
+}


### PR DESCRIPTION
Before this adjustment, if the test method threw an exception before reading all parameter, you would just get an error about reading the parameters and not the original exception.

Then because `checkUsedParameters()` threw an exception instead of adding it to the error list it would not report previous errors. By adding the error to the error collector instead of throwing, the error output would show both the original exception and the error about not all parameters being used.