### PR TITLE
Fix publishing config: packaging type, version source, Gradle dependency syntax

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
-group 'com.github.ignaciotcrespo'
-version '1.0.7'
+group GROUP
+version VERSION_NAME
 
 apply plugin: 'java'
 // for travis-ci

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 POM_NAME=JUnitWithParams
 POM_ARTIFACT_ID=junitwithparams
-POM_PACKAGING=aar
+POM_PACKAGING=jar
 VERSION_NAME=1.0.7
 VERSION_CODE=7
 GROUP=com.github.ignaciotcrespo

--- a/readme.md
+++ b/readme.md
@@ -100,7 +100,7 @@ JUnitWithParams is available as Maven artifact:
 To use JUnitWithParams in a Gradle build add this to your dependencies:
 
 ```
-testCompile 'com.github.ignaciotcrespo:junitwithparams:1.0.7'
+testImplementation 'com.github.ignaciotcrespo:junitwithparams:1.0.7'
 ```
 
 # Contribution


### PR DESCRIPTION
Fixes several issues in the Maven publishing setup:

- `gradle.properties`: fix POM_PACKAGING from `aar` to `jar` (this is a Java library, not Android)
- `build.gradle`: read `GROUP` and `VERSION_NAME` from gradle.properties instead of hardcoding
- `readme.md`: update deprecated `testCompile` to `testImplementation`

Relates to #5

Generated with [Claude Code](https://claude.ai/code)